### PR TITLE
Add usage instructions for BBEdit 14.

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -148,3 +148,13 @@ Make sure to read through to [CONFIG.md#terraformls](https://github.com/neovim/n
     ],
 },
 ```
+
+## BBEdit
+
+*BBEdit 14 [added support](https://www.barebones.com/support/bbedit/lsp-notes.html) for the Language Server Protocol so you'll need to upgrade to version 14 to use; this won't work for older versions of BBEdit*.
+
+- Open Preferences > Languages
+- In *Language-specific settings* section, add an entry for Terraform
+- In the Server tab, Set *Command* to `terraform-ls` and *Arguments* to `serve`
+- Once you've correctly installed `terraform-ls` and configured BBEdit, the status indicator on this settings panel will flip to green
+- If you'd like to pass any [settings](./SETTINGS.md) to the server you can do so via the *Arguments* field.


### PR DESCRIPTION
## Summary

Adds usage instructions for BBEdit 14.

## More info

The language server seems to work fairly well with BBEdit's new LSP support. It nicely suggests fields on a resource. The resource type selection doesn't update-as-you-type but I'm not yet sure if that's an issue with BBEdit or this language server; I'll file an issue if the latter once I've had the chance to do a little more debugging.